### PR TITLE
fix: fixed bug in the api middleware auth

### DIFF
--- a/utils/apiAuthentication.js
+++ b/utils/apiAuthentication.js
@@ -10,15 +10,17 @@ const authenticateAccess = async (ctx, next) => {
     ctx.body = `There is no api with the name: ${apiName}.`;
     ctx.status = 200;
   } else {
+    
+    // keys from database
     const [public, apiKey, apiSecretKey] = api.split(':');
+    //keys from request
+    const { api_key, api_secret_key } = ctx.request.headers;
 
-    if (public === 'true' && ctx.request.method === 'GET') {
-      await next();
-    } else if (ctx.request.headers.api_key === apiKey && ctx.request.headers.api_secret_key === apiSecretKey) {
-      await next();
-    } else {
+    if (public === 'true' && ctx.request.method === 'GET') await next();
+    else if (api_key === apiKey && api_secret_key === apiSecretKey) await next();
+    else {
       ctx.body = 'You do not have the right permissions to access this api.'
-      ctx.status = 200;
+      ctx.status = 403;
     }
   }
 }


### PR DESCRIPTION
It was only executing the second condition in the "if else" if the api was of type private, however that meant it was not letting rightful public api requests (for PUT POST and DELETE) through.